### PR TITLE
fix(hf_trainer): force fp32 master weights at from_config

### DIFF
--- a/manylatents/lightning/hf_trainer.py
+++ b/manylatents/lightning/hf_trainer.py
@@ -139,6 +139,16 @@ class HFTrainerModule(LightningModule):
             )
             for key, value in (self.config.model_config_overrides or {}).items():
                 setattr(model_config, key, value)
+            # Force fp32 master weights at construction. Some HF configs ship
+            # `torch_dtype: float16` (e.g. EleutherAI/pythia-*), and modern
+            # transformers' `from_config` honors that field — building the
+            # student in pure fp16 will NaN once gradients flow under any
+            # mixed-precision regime. The optional post-construction
+            # `.to(dtype=normalized_torch_dtype)` below still lets callers
+            # downcast intentionally, but the construction-time dtype is now
+            # unconditionally fp32 regardless of what the source config or
+            # `model_config_overrides` carried.
+            model_config.torch_dtype = torch.float32
             from_config_kwargs: Dict[str, Any] = {
                 "trust_remote_code": self.config.trust_remote_code,
             }

--- a/manylatents/lightning/tests/test_hf_trainer_from_config.py
+++ b/manylatents/lightning/tests/test_hf_trainer_from_config.py
@@ -97,3 +97,108 @@ def test_hf_trainer_from_config_tokenizer_falls_back_to_model_name(monkeypatch):
     module.configure_model()
 
     assert calls["tokenizer_source"] == "EleutherAI/pythia-70m"
+
+
+def test_hf_trainer_from_config_forces_fp32_master_weights(monkeypatch):
+    """Regression: pythia configs ship `torch_dtype=float16` in config.json,
+    and modern transformers' `from_config` honors it. The runner must force
+    fp32 at construction so master weights remain fp32 — otherwise the
+    student NaNs once gradients flow under mixed-precision training.
+
+    Simulates the pythia case: source config carries fp16; assert that the
+    config seen by `from_config` has been promoted to fp32.
+    """
+    seen = {}
+
+    class DummyNetwork:
+        def to(self, dtype=None):
+            seen["post_to_dtype"] = dtype
+            return self
+
+    class DummyConfig:
+        # Mimics what AutoConfig.from_pretrained returns for pythia: fp16.
+        torch_dtype = torch.float16
+
+    def fake_from_config(cfg, **kwargs):
+        seen["from_config_torch_dtype"] = cfg.torch_dtype
+        return DummyNetwork()
+
+    monkeypatch.setattr(
+        "manylatents.lightning.hf_trainer.AutoConfig.from_pretrained",
+        lambda *args, **kwargs: DummyConfig(),
+    )
+    monkeypatch.setattr(
+        "manylatents.lightning.hf_trainer.AutoModelForCausalLM.from_config",
+        fake_from_config,
+    )
+    monkeypatch.setattr(
+        "manylatents.lightning.hf_trainer.AutoTokenizer.from_pretrained",
+        lambda *args, **kwargs: object(),
+    )
+
+    cfg = HFTrainerConfig(
+        model_name_or_path="EleutherAI/pythia-70m",
+        init_mode="from_config",
+        model_config_name_or_path="EleutherAI/pythia-70m",
+        tokenizer_name="EleutherAI/pythia-70m",
+        torch_dtype=torch.float32,
+    )
+    module = HFTrainerModule(cfg)
+    module.configure_model()
+
+    assert seen["from_config_torch_dtype"] == torch.float32, (
+        "Master weights at from_config must be fp32 even when the source "
+        "config carries fp16; got "
+        f"{seen.get('from_config_torch_dtype')}"
+    )
+
+
+def test_hf_trainer_from_config_overrides_take_precedence_for_non_dtype_keys(monkeypatch):
+    """The fp32 dtype force must not clobber unrelated `model_config_overrides`.
+    Override `num_hidden_layers` and `hidden_size`; both must reach
+    `from_config`, while `torch_dtype` is still fp32.
+    """
+    seen = {}
+
+    class DummyNetwork:
+        def to(self, dtype=None):
+            return self
+
+    class DummyConfig:
+        torch_dtype = torch.float16
+        num_hidden_layers = 24
+        hidden_size = 1024
+
+    def fake_from_config(cfg, **kwargs):
+        seen["torch_dtype"] = cfg.torch_dtype
+        seen["num_hidden_layers"] = cfg.num_hidden_layers
+        seen["hidden_size"] = cfg.hidden_size
+        return DummyNetwork()
+
+    monkeypatch.setattr(
+        "manylatents.lightning.hf_trainer.AutoConfig.from_pretrained",
+        lambda *args, **kwargs: DummyConfig(),
+    )
+    monkeypatch.setattr(
+        "manylatents.lightning.hf_trainer.AutoModelForCausalLM.from_config",
+        fake_from_config,
+    )
+    monkeypatch.setattr(
+        "manylatents.lightning.hf_trainer.AutoTokenizer.from_pretrained",
+        lambda *args, **kwargs: object(),
+    )
+
+    cfg = HFTrainerConfig(
+        model_name_or_path="EleutherAI/pythia-70m",
+        init_mode="from_config",
+        model_config_name_or_path="EleutherAI/pythia-70m",
+        model_config_overrides={"num_hidden_layers": 2, "hidden_size": 64},
+        tokenizer_name="EleutherAI/pythia-70m",
+        torch_dtype=torch.float32,
+    )
+    module = HFTrainerModule(cfg)
+    module.configure_model()
+
+    assert seen["torch_dtype"] == torch.float32
+    assert seen["num_hidden_layers"] == 2
+    assert seen["hidden_size"] == 64


### PR DESCRIPTION
## Summary

- `EleutherAI/pythia-*` HF configs ship `torch_dtype: float16` in `config.json`. Modern `transformers.AutoModelForCausalLM.from_config` honors that field, so `init_mode=\"from_config\"` builds the student in pure fp16. Under any mixed-precision Lightning regime, the master weights NaN once gradients flow — reliably at step 9 across all three pythia sizes I tested in a downstream consumer (410m / 1b / 2.8b).
- Force `model_config.torch_dtype = torch.float32` before `from_config`. The optional post-construction `.to(dtype=normalized_torch_dtype)` still lets callers downcast intentionally — the construction-time master-weight dtype is just unconditionally fp32 now, regardless of what the source config or \`model_config_overrides\` carried.
- Adds two regression tests (one for the pythia-fp16 case, one to guard against the dtype force clobbering unrelated \`model_config_overrides\`).

## Why other families were unaffected

| family | \`config.torch_dtype\` (from HF Hub) | NaN, pre-fix |
|---|---|---|
| pythia-410m / 1b / 2.8b / 6.9b | \`float16\` | yes — NaN at step 9 |
| Qwen2.5-0.5B / 1.5B | \`bfloat16\` | no (bf16 has fp32-equivalent exponent range) |
| bert-base / deberta-v3-xsmall | \`None\` → fp32 | no |

fp16 is uniquely dangerous: same width as bf16 but a much smaller exponent range, so optimizer state and accumulated gradients overflow trivially.

## Why this didn't bite earlier

Older \`transformers.from_config\` ignored \`config.torch_dtype\` and always built in fp32. Newer transformers (≈4.34+) honor it. The post-construction \`.to(dtype=normalized_torch_dtype)\` masks the bug as long as the user passes fp32, but it's "safe by accident" — anyone using \`init_from_scratch\` with no explicit \`torch_dtype\` (or a non-fp32 one) reintroduces the silent fp16-master-weights case.

## Test plan

- [x] \`uv run pytest manylatents/lightning/tests/test_hf_trainer_from_config.py -x -q\` — 4 passed (2 existing + 2 new)
- [x] \`uv run pytest tests/ -q\` — 240 passed, 3 pre-existing failures in deprecated \`tests/pipeline/\` unrelated to this change
- [x] \`uv run pytest manylatents/callbacks/tests/ -q\` — 30 passed
- [x] Verified end-to-end downstream: 12 pythia F1 cells fanned out post-fix (Mila A100 ×8 for 410m+1b, Fir 4×H100 DDP ×4 for 2.8b) — all currently NaN-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)